### PR TITLE
correct typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ management. To check out the project for development, run:
 
 .. code:: bash
 
-  $ git clone --recursive-submodules https://github.com/alethiophile/qtoml
+  $ git clone --recurse-submodules https://github.com/alethiophile/qtoml
   $ cd qtoml
   $ poetry install
 


### PR DESCRIPTION
Really minor README.rst fix:

'git clone --recursive-submodules ...' should be
'git clone --recurse-submodules ...'